### PR TITLE
chore: release v0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "graphql-toolkit"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/graphql-toolkit/CHANGELOG.md
+++ b/graphql-toolkit/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/LNSD/graphql-toolkit/compare/v0.0.0...v0.0.1) - 2024-05-19
+
+### Added
+- *(graphql-toolkit)* add pretty formatter ([#13](https://github.com/LNSD/graphql-toolkit/pull/13))
+- *(graphql-toolkit)* add compact formatter ([#9](https://github.com/LNSD/graphql-toolkit/pull/9))
+- *(graphql-toolkit)* add async-graphql parser and ast ([#2](https://github.com/LNSD/graphql-toolkit/pull/2))
+
+### Fixed
+- *(graphql-toolkit)* align query shorthand format with async-graphql ([#10](https://github.com/LNSD/graphql-toolkit/pull/10))
+
+### Other
+- *(graphql-toolkit)* add module documentation ([#16](https://github.com/LNSD/graphql-toolkit/pull/16))
+- *(graphql-toolkit)* homogenize formatter tests and disable non-deterministic tests ([#15](https://github.com/LNSD/graphql-toolkit/pull/15))

--- a/graphql-toolkit/Cargo.toml
+++ b/graphql-toolkit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit"
 description = "A collection of Rust modules to process GraphQL documents"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]


### PR DESCRIPTION
## 🤖 New release
* `graphql-toolkit`: 0.0.0 -> 0.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.1](https://github.com/LNSD/graphql-toolkit/compare/v0.0.0...v0.0.1) - 2024-05-19

### Added
- *(graphql-toolkit)* add pretty formatter ([#13](https://github.com/LNSD/graphql-toolkit/pull/13))
- *(graphql-toolkit)* add compact formatter ([#9](https://github.com/LNSD/graphql-toolkit/pull/9))
- *(graphql-toolkit)* add async-graphql parser and ast ([#2](https://github.com/LNSD/graphql-toolkit/pull/2))

### Fixed
- *(graphql-toolkit)* align query shorthand format with async-graphql ([#10](https://github.com/LNSD/graphql-toolkit/pull/10))

### Other
- *(graphql-toolkit)* add module documentation ([#16](https://github.com/LNSD/graphql-toolkit/pull/16))
- *(graphql-toolkit)* homogenize formatter tests and disable non-deterministic tests ([#15](https://github.com/LNSD/graphql-toolkit/pull/15))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).