### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-toolkit-ast"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-graphql-parser",
  "graphql-toolkit-value",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-toolkit-value"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-graphql-value",
 ]

--- a/graphql-toolkit-ast/CHANGELOG.md
+++ b/graphql-toolkit-ast/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.1.1...graphql-toolkit-ast-v0.1.2) - 2024-06-06
+
+### Other
+- set crates repository url ([#42](https://github.com/LNSD/graphql-toolkit/pull/42))
+
 ## [0.1.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.1.0...graphql-toolkit-ast-v0.1.1) - 2024-06-06
 
 ### Added

--- a/graphql-toolkit-ast/Cargo.toml
+++ b/graphql-toolkit-ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-ast"
 description = "A Rust library for working with GraphQL abstract syntax trees"
-version = "0.1.1"
+version = "0.1.2"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"
@@ -10,4 +10,4 @@ rust-version = "1.71.1"
 
 [dependencies]
 async-graphql-parser = "7.0.5"
-graphql-toolkit-value = { version = "0.1.0", path = "../graphql-toolkit-value" }
+graphql-toolkit-value = { version = "0.1.1", path = "../graphql-toolkit-value" }

--- a/graphql-toolkit-value/CHANGELOG.md
+++ b/graphql-toolkit-value/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-value-v0.1.0...graphql-toolkit-value-v0.1.1) - 2024-06-06
+
+### Other
+- set crates repository url ([#42](https://github.com/LNSD/graphql-toolkit/pull/42))

--- a/graphql-toolkit-value/Cargo.toml
+++ b/graphql-toolkit-value/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-value"
 description = "GraphQL Toolkit value definitions"
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"

--- a/graphql-toolkit/Cargo.toml
+++ b/graphql-toolkit/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
-graphql-toolkit-ast = { version = "0.1.1", path = "../graphql-toolkit-ast" }
+graphql-toolkit-ast = { version = "0.1.2", path = "../graphql-toolkit-ast" }
 graphql-toolkit-parser = { version = "0.1.1", path = "../graphql-toolkit-parser" }
 itoa = { version = "1.0", default-features = false }
 ryu = { version = "1.0", default-features = false }


### PR DESCRIPTION
## 🤖 New release
* `graphql-toolkit-ast`: 0.1.1 -> 0.1.2
* `graphql-toolkit-value`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `graphql-toolkit-ast`
<blockquote>

## [0.1.2](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.1.1...graphql-toolkit-ast-v0.1.2) - 2024-06-06

### Other
- set crates repository url ([#42](https://github.com/LNSD/graphql-toolkit/pull/42))
</blockquote>

## `graphql-toolkit-value`
<blockquote>

## [0.1.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-value-v0.1.0...graphql-toolkit-value-v0.1.1) - 2024-06-06

### Other
- set crates repository url ([#42](https://github.com/LNSD/graphql-toolkit/pull/42))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).