### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-toolkit-parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_matches",
  "async-graphql-parser",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-toolkit-writer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-graphql-value",

--- a/graphql-toolkit-parser/CHANGELOG.md
+++ b/graphql-toolkit-parser/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.1.1...graphql-toolkit-parser-v0.1.2) - 2024-06-10
+
+### Added
+- *(parser)* add parse executable document tests ([#45](https://github.com/LNSD/graphql-toolkit/pull/45))
+
+### Other
+- *(parser)* rename parse executable document test suite ([#47](https://github.com/LNSD/graphql-toolkit/pull/47))

--- a/graphql-toolkit-parser/Cargo.toml
+++ b/graphql-toolkit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-parser"
 description = "A GraphQL document parser"
-version = "0.1.1"
+version = "0.1.2"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"

--- a/graphql-toolkit-writer/CHANGELOG.md
+++ b/graphql-toolkit-writer/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.1.0...graphql-toolkit-writer-v0.1.1) - 2024-06-10
+
+### Added
+- *(writer)* add pretty formatter ([#54](https://github.com/LNSD/graphql-toolkit/pull/54))

--- a/graphql-toolkit-writer/Cargo.toml
+++ b/graphql-toolkit-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-writer"
 description = "A GraphQL document writer"
-version = "0.1.0"
+version = "0.1.1"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"

--- a/graphql-toolkit/Cargo.toml
+++ b/graphql-toolkit/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 graphql-toolkit-ast = { version = "0.1.2", path = "../graphql-toolkit-ast" }
-graphql-toolkit-parser = { version = "0.1.1", path = "../graphql-toolkit-parser" }
+graphql-toolkit-parser = { version = "0.1.2", path = "../graphql-toolkit-parser" }
 itoa = { version = "1.0", default-features = false }
 ryu = { version = "1.0", default-features = false }
 


### PR DESCRIPTION
## 🤖 New release
* `graphql-toolkit-parser`: 0.1.1 -> 0.1.2
* `graphql-toolkit-writer`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `graphql-toolkit-parser`
<blockquote>

## [0.1.2](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.1.1...graphql-toolkit-parser-v0.1.2) - 2024-06-10

### Added
- *(parser)* add parse executable document tests ([#45](https://github.com/LNSD/graphql-toolkit/pull/45))

### Other
- *(parser)* rename parse executable document test suite ([#47](https://github.com/LNSD/graphql-toolkit/pull/47))
</blockquote>

## `graphql-toolkit-writer`
<blockquote>

## [0.1.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.1.0...graphql-toolkit-writer-v0.1.1) - 2024-06-10

### Added
- *(writer)* add pretty formatter ([#54](https://github.com/LNSD/graphql-toolkit/pull/54))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).