### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "0.0.0"
 
 [[package]]
 name = "graphql-toolkit-ast"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "graphql-toolkit-value",
  "serde",
@@ -119,7 +119,7 @@ version = "0.0.0"
 
 [[package]]
 name = "graphql-toolkit-parser"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "graphql-toolkit-ast",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-toolkit-value"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "indexmap",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-toolkit-writer"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "graphql-toolkit-ast",

--- a/graphql-toolkit-ast/CHANGELOG.md
+++ b/graphql-toolkit-ast/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.1.2...graphql-toolkit-ast-v0.2.0) - 2024-06-15
+
+### Added
+- *(graphql-toolkit-ast)* fork async-graphql-parser ([#63](https://github.com/LNSD/graphql-toolkit/pull/63))
+
+### Other
+- *(graphql-toolkit-ast)* add fork notice to readme ([#64](https://github.com/LNSD/graphql-toolkit/pull/64))
+- *(graphql-toolkit-ast)* use graphql-toolkit-value released version ([#58](https://github.com/LNSD/graphql-toolkit/pull/58))
+
 ## [0.1.2](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.1.1...graphql-toolkit-ast-v0.1.2) - 2024-06-06
 
 ### Other

--- a/graphql-toolkit-ast/Cargo.toml
+++ b/graphql-toolkit-ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-ast"
 description = "A Rust library for working with GraphQL abstract syntax trees"
-version = "0.1.2"
+version = "0.2.0"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"
@@ -9,5 +9,5 @@ edition = "2021"
 rust-version = "1.71.1"
 
 [dependencies]
-graphql-toolkit-value = { version = "0.1.1", path = "../graphql-toolkit-value" }
+graphql-toolkit-value = { version = "0.2.0", path = "../graphql-toolkit-value" }
 serde = { version = "1.0.203", features = ["derive"] }

--- a/graphql-toolkit-parser/CHANGELOG.md
+++ b/graphql-toolkit-parser/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.1.2...graphql-toolkit-parser-v0.203) - 2024-06-15
+
+### Added
+- *(graphql-toolkit-parser)* fork async-graphql-parser ([#65](https://github.com/LNSD/graphql-toolkit/pull/65))
+
+### Other
+- *(graphql-toolkit-parser)* add fork notice to readme ([#67](https://github.com/LNSD/graphql-toolkit/pull/67))
+- *(graphql-toolkit-parser)* use graphql-toolkit-ast released version ([#61](https://github.com/LNSD/graphql-toolkit/pull/61))
+
 ## [0.1.2](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.1.1...graphql-toolkit-parser-v0.1.2) - 2024-06-10
 
 ### Added

--- a/graphql-toolkit-parser/Cargo.toml
+++ b/graphql-toolkit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-parser"
 description = "A GraphQL document parser"
-version = "0.1.2"
+version = "0.2.0"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.71.1"
 
 [dependencies]
-graphql-toolkit-ast = { version = "0.1.2", path = "../graphql-toolkit-ast" }
+graphql-toolkit-ast = { version = "0.2.0", path = "../graphql-toolkit-ast" }
 pest = "2.7.10"
 serde = "1.0.203"
 

--- a/graphql-toolkit-value/CHANGELOG.md
+++ b/graphql-toolkit-value/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-value-v0.1.1...graphql-toolkit-value-v0.2.0) - 2024-06-15
+
+### Added
+- *(graphql-toolkit-value)* fork async-graphql-value ([#60](https://github.com/LNSD/graphql-toolkit/pull/60))
+
 ## [0.1.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-value-v0.1.0...graphql-toolkit-value-v0.1.1) - 2024-06-06
 
 ### Other

--- a/graphql-toolkit-value/Cargo.toml
+++ b/graphql-toolkit-value/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-value"
 description = "GraphQL Toolkit value definitions"
-version = "0.1.1"
+version = "0.2.0"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"

--- a/graphql-toolkit-writer/CHANGELOG.md
+++ b/graphql-toolkit-writer/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.1.1...graphql-toolkit-writer-v0.2.0) - 2024-06-15
+
+### Other
+- *(graphql-toolkit-writer)* use graphql-toolkit-ast workspace version ([#66](https://github.com/LNSD/graphql-toolkit/pull/66))
+- *(graphql-toolkit-writer)* use graphql-toolkit-ast released version ([#62](https://github.com/LNSD/graphql-toolkit/pull/62))
+
 ## [0.1.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.1.0...graphql-toolkit-writer-v0.1.1) - 2024-06-10
 
 ### Added

--- a/graphql-toolkit-writer/Cargo.toml
+++ b/graphql-toolkit-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-writer"
 description = "A GraphQL document writer"
-version = "0.1.1"
+version = "0.2.0"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"
@@ -10,11 +10,11 @@ rust-version = "1.71.1"
 
 [dependencies]
 anyhow = "1.0.86"
-graphql-toolkit-ast = { version = "0.1.2", path = "../graphql-toolkit-ast" }
+graphql-toolkit-ast = { version = "0.2.0", path = "../graphql-toolkit-ast" }
 itoa = { version = "1.0.11", default-features = false }
 ryu = { version = "1.0.18", default-features = false }
 
 [dev-dependencies]
-graphql-toolkit-parser = { version = "0.1.2", path = "../graphql-toolkit-parser" }
+graphql-toolkit-parser = { version = "0.2.0", path = "../graphql-toolkit-parser" }
 indoc = "2.0.5"
 insta = "1.39.0"


### PR DESCRIPTION
## 🤖 New release
* `graphql-toolkit-ast`: 0.1.2 -> 0.2.0
* `graphql-toolkit-value`: 0.1.1 -> 0.2.0
* `graphql-toolkit-parser`: 0.1.2 -> 0.2.0
* `graphql-toolkit-writer`: 0.1.1 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `graphql-toolkit-ast`
<blockquote>

## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.1.2...graphql-toolkit-ast-v0.2.0) - 2024-06-15

### Added
- *(graphql-toolkit-ast)* fork async-graphql-parser ([#63](https://github.com/LNSD/graphql-toolkit/pull/63))

### Other
- *(graphql-toolkit-ast)* add fork notice to readme ([#64](https://github.com/LNSD/graphql-toolkit/pull/64))
- *(graphql-toolkit-ast)* use graphql-toolkit-value released version ([#58](https://github.com/LNSD/graphql-toolkit/pull/58))
</blockquote>

## `graphql-toolkit-value`
<blockquote>

## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-value-v0.1.1...graphql-toolkit-value-v0.2.0) - 2024-06-15

### Added
- *(graphql-toolkit-value)* fork async-graphql-value ([#60](https://github.com/LNSD/graphql-toolkit/pull/60))
</blockquote>

## `graphql-toolkit-parser`
<blockquote>

## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.1.2...graphql-toolkit-parser-v0.2.0) - 2024-06-15

### Added
- *(graphql-toolkit-parser)* fork async-graphql-parser ([#65](https://github.com/LNSD/graphql-toolkit/pull/65))

### Other
- *(graphql-toolkit-parser)* add fork notice to readme ([#67](https://github.com/LNSD/graphql-toolkit/pull/67))
- *(graphql-toolkit-parser)* use graphql-toolkit-ast released version ([#61](https://github.com/LNSD/graphql-toolkit/pull/61))
</blockquote>

## `graphql-toolkit-writer`
<blockquote>

## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.1.1...graphql-toolkit-writer-v0.2.0) - 2024-06-15

### Other
- *(graphql-toolkit-writer)* use graphql-toolkit-ast workspace version ([#66](https://github.com/LNSD/graphql-toolkit/pull/66))
- *(graphql-toolkit-writer)* use graphql-toolkit-ast released version ([#62](https://github.com/LNSD/graphql-toolkit/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).