### PR TITLE
chore: release v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ version = "0.0.0"
 
 [[package]]
 name = "graphql-toolkit-ast"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "graphql-toolkit-value",
  "serde",
@@ -123,7 +123,7 @@ version = "0.0.0"
 
 [[package]]
 name = "graphql-toolkit-parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_matches",
  "graphql-toolkit-ast",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-toolkit-writer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "graphql-toolkit-ast",

--- a/graphql-toolkit-ast/CHANGELOG.md
+++ b/graphql-toolkit-ast/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.2.0...graphql-toolkit-ast-v0.2.1) - 2024-09-23
+
+### Added
+
+- *(graphql-toolkit-ast)* remove ast types serde support ([#71](https://github.com/LNSD/graphql-toolkit/pull/71))
+
 ## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.1.2...graphql-toolkit-ast-v0.2.0) - 2024-06-15
 
 ### Added

--- a/graphql-toolkit-ast/Cargo.toml
+++ b/graphql-toolkit-ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-ast"
 description = "A Rust library for working with GraphQL abstract syntax trees"
-version = "0.2.0"
+version = "0.2.1"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"

--- a/graphql-toolkit-parser/CHANGELOG.md
+++ b/graphql-toolkit-parser/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.2.0...graphql-toolkit-parser-v0.2.1) - 2024-09-23
+
+### Other
+
+- updated the following local packages: graphql-toolkit-ast
+
 ## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.1.2...graphql-toolkit-parser-v0.203) - 2024-06-15
 
 ### Added

--- a/graphql-toolkit-parser/Cargo.toml
+++ b/graphql-toolkit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-parser"
 description = "A GraphQL document parser"
-version = "0.2.0"
+version = "0.2.1"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"
@@ -9,7 +9,7 @@ edition = "2021"
 rust-version = "1.71.1"
 
 [dependencies]
-graphql-toolkit-ast = { version = "0.2.0", path = "../graphql-toolkit-ast" }
+graphql-toolkit-ast = { version = "0.2.1", path = "../graphql-toolkit-ast" }
 pest = "2.7.10"
 serde = "1.0.203"
 

--- a/graphql-toolkit-writer/CHANGELOG.md
+++ b/graphql-toolkit-writer/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.2.0...graphql-toolkit-writer-v0.2.1) - 2024-09-23
+
+### Other
+
+- updated the following local packages: graphql-toolkit-ast
+
 ## [0.2.0](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.1.1...graphql-toolkit-writer-v0.2.0) - 2024-06-15
 
 ### Other

--- a/graphql-toolkit-writer/Cargo.toml
+++ b/graphql-toolkit-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql-toolkit-writer"
 description = "A GraphQL document writer"
-version = "0.2.0"
+version = "0.2.1"
 repository = "https://github.com/LNSD/graphql-toolkit"
 authors = ["Lorenzo Delgado (LNSD) <lnsdev@proton.me>"]
 license = "Apache-2.0"
@@ -10,11 +10,11 @@ rust-version = "1.71.1"
 
 [dependencies]
 anyhow = "1.0.86"
-graphql-toolkit-ast = { version = "0.2.0", path = "../graphql-toolkit-ast" }
+graphql-toolkit-ast = { version = "0.2.1", path = "../graphql-toolkit-ast" }
 itoa = { version = "1.0.11", default-features = false }
 ryu = { version = "1.0.18", default-features = false }
 
 [dev-dependencies]
-graphql-toolkit-parser = { version = "0.2.0", path = "../graphql-toolkit-parser" }
+graphql-toolkit-parser = { version = "0.2.1", path = "../graphql-toolkit-parser" }
 indoc = "2.0.5"
 insta = "1.39.0"


### PR DESCRIPTION
## 🤖 New release
* `graphql-toolkit-ast`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `graphql-toolkit-parser`: 0.2.0 -> 0.2.1
* `graphql-toolkit-writer`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `graphql-toolkit-ast`
<blockquote>

## [0.2.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-ast-v0.2.0...graphql-toolkit-ast-v0.2.1) - 2024-09-23

### Added

- *(graphql-toolkit-ast)* remove ast types serde support ([#71](https://github.com/LNSD/graphql-toolkit/pull/71))
</blockquote>

## `graphql-toolkit-parser`
<blockquote>

## [0.2.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-parser-v0.2.0...graphql-toolkit-parser-v0.2.1) - 2024-09-23

### Other

- updated the following local packages: graphql-toolkit-ast
</blockquote>

## `graphql-toolkit-writer`
<blockquote>

## [0.2.1](https://github.com/LNSD/graphql-toolkit/compare/graphql-toolkit-writer-v0.2.0...graphql-toolkit-writer-v0.2.1) - 2024-09-23

### Other

- updated the following local packages: graphql-toolkit-ast
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).